### PR TITLE
requestをしたuserIdを取得し、自動でreviewデータベースに挿入

### DIFF
--- a/app/controllers/review/ReviewCommitController.scala
+++ b/app/controllers/review/ReviewCommitController.scala
@@ -14,11 +14,12 @@ class ReviewCommitController @javax.inject.Inject()(
     ) extends AbstractController(cc) with I18nSupport {
         implicit lazy val executionContext = defaultExecutionContext
 
-    def viewForReview(castId: Long) = Action.async {implicit request =>
+    def viewForReview(castId: Long) = (Action andThen AuthenticationAction()).async {implicit request =>
       val vv = SiteViewValueReview(
             layout = ViewValuePageLayout(id = request.uri),
             form = SiteViewValueReview.formReview,
             castId = castId,
+            userId = request.userId,
         )
         Future.successful(Ok(views.html.site.review.post.Main(vv)))
     }
@@ -30,12 +31,13 @@ class ReviewCommitController @javax.inject.Inject()(
                     layout  = ViewValuePageLayout(id = request.uri),
                     form    = errors,
                     castId = castId,
+                    userId = request.userId,
                 )
                 Future.successful(Ok(views.html.site.review.post.Main(vv)))
             },
             form => {
                 for{
-                    id <- daoReviewCommit.post(form.toReview(castId))
+                    id <- daoReviewCommit.post(form.toReview(castId, request.userId))
                 } yield {
                 Redirect("/cast/list")
                 }

--- a/app/model/site/review/ReviewCommit.scala
+++ b/app/model/site/review/ReviewCommit.scala
@@ -13,6 +13,7 @@ case class SiteViewValueReview(
     layout: ViewValuePageLayout,
     form:   Form[ReviewForm],
     castId: Long,
+    userId: Long,
 )
 
 object SiteViewValueReview {
@@ -24,8 +25,8 @@ object SiteViewValueReview {
         fun:            Double,
         hospitality:    Double,
     ){
-        def toReview(castId: Long) =
-            Review(None, castId, 1, title, body, star, fun, hospitality, LocalDateTime.now())
+        def toReview(castId: Long, userId: Long) =
+            Review(None, castId, userId, title, body, star, fun, hospitality, LocalDateTime.now())
     }
 
     val formReview = Form(


### PR DESCRIPTION
さっきまでは仮の値の、userID=1を挿入してreviewをpostしていたがrequestを行なったuserのuserIdを自動で挿入できるように修正。